### PR TITLE
Rob/Hotfix for crash when clicking create new walkthrough button

### DIFF
--- a/app/src/main/java/com/plusmobileapps/safetyapp/surveys/landing/SurveyLandingFragment.java
+++ b/app/src/main/java/com/plusmobileapps/safetyapp/surveys/landing/SurveyLandingFragment.java
@@ -80,9 +80,10 @@ public class SurveyLandingFragment extends Fragment
         prefManager = new PrefManager(getContext());
         if (prefManager.isFirstTimeLaunch()) {
             presenter.firstAppLaunch();
-        } else {
-            presenter.start();
         }
+
+        // presenter has to be started in either case
+        presenter.start();
     }
 
     @Override


### PR DESCRIPTION
This resolves the crashing issue when clicking create new walkthrough on first time app launch. The presenter wasn't being started in SurveyLandingFragment.onResume().