### PR TITLE
US-40: Corrected Headers of Walkthroughs for In Progress and Complete

### DIFF
--- a/app/src/main/java/com/plusmobileapps/safetyapp/walkthrough/landing/WalkthroughLandingAdapter.java
+++ b/app/src/main/java/com/plusmobileapps/safetyapp/walkthrough/landing/WalkthroughLandingAdapter.java
@@ -43,17 +43,19 @@ public class WalkthroughLandingAdapter extends RecyclerView.Adapter<WalkthroughL
     public void onBindViewHolder(final CardViewHolder holder, int position) {
         Log.d(TAG, "In onBindViewHolder");
         if(walkthroughs.size() > 0) {
-            walkthrough = walkthroughs.get(position);
+            int i = walkthroughs.size() - position - 1;
+            walkthrough = walkthroughs.get(i);
             TextView header = holder.getHeader();
 
-            //handle the header visibility
-            if (position <= 1) {
+            if(walkthrough.isInProgress()) {
                 header.setVisibility(View.VISIBLE);
-                if (position == 1) {
-                    header.setText(R.string.viewholder_header_completed);
-                } else {
-                    header.setText(R.string.viewholder_header_inprogress);
-                }
+                header.setText(R.string.viewholder_header_inprogress);
+            } else if(position == 0) {
+                header.setVisibility(View.VISIBLE);
+                header.setText(R.string.viewholder_header_completed);
+            } else if(position == 1 && walkthroughs.get(walkthroughs.size() - 1).isInProgress()) {
+                header.setVisibility(View.VISIBLE);
+                header.setText(R.string.viewholder_header_completed);
             } else {
                 header.setVisibility(View.GONE);
             }

--- a/app/src/main/java/com/plusmobileapps/safetyapp/walkthrough/landing/WalkthroughLandingPresenter.java
+++ b/app/src/main/java/com/plusmobileapps/safetyapp/walkthrough/landing/WalkthroughLandingPresenter.java
@@ -28,20 +28,20 @@ public class WalkthroughLandingPresenter implements WalkthroughLandingContract.P
 
     @Override
     public void walkthroughClicked(int position) {
-        final Walkthrough walkthrough = walkthroughs.get(position);
+        final Walkthrough walkthrough = walkthroughs.get(walkthroughs.size() - position - 1);
         view.openWalkthrough(walkthrough.getWalkthroughId(), walkthrough.getName());
     }
 
     @Override
     public void deleteInProgressWalkthroughConfirmed() {
-        new DeleteWalkthrough(walkthroughs.get(0), view).execute();
+        new DeleteWalkthrough(walkthroughs.get(walkthroughs.size() - 1), view).execute();
         createNewWalkthrough();
     }
 
     @Override
     public void createNewWalkthroughIconClicked() {
         if(walkthroughs.size() > 0) {
-            if(walkthroughs.get(0).isInProgress()) {
+            if(walkthroughs.get(walkthroughs.size() - 1).isInProgress()) {
                 view.showInProcessConfirmationDialog();
             } else {
                 createNewWalkthrough();


### PR DESCRIPTION
# Overview
I corrected the logic for the headings of the walkthroughs and corrected the order in which they show up. 

# Description
The headers were relying on position to determine how they appeared. It needed additional logic for whether or not they showed up and reordering of the list on the screen so the newest walkthrough would always be on top.

# Screenshot
N/A

# Trello Link
https://trello.com/c/tBDtrB7X/44-us-40-as-a-user-i-want-only-completed-walkthroughs-to-be-categorized-in-the-complete-section-of-the-walkthrough-landing-page-so

# Merge Checklist 
[X] Backmerged master in your branch.
[X] Refactored all instances of "survey" to "walkthrough" in any files touched.
[X] All unit tests built and passed, or TODO with linked stories if unit tests
    have failed.