### PR TITLE
corrected typo so alcohol is spelled correctly

### DIFF
--- a/app/src/main/res/raw/question.json
+++ b/app/src/main/res/raw/question.json
@@ -10,7 +10,7 @@
     },
     {
         "questionId": "2",
-        "questionText": "Count signs with positive behavioral expecations of students.\r\n",
+        "questionText": "Count signs with positive behavioral expectations of students.\r\n",
         "ratingOption1": "None",
         "ratingOption2": "1 or more",
         "ratingOption3": "",
@@ -100,7 +100,7 @@
     },
     {
         "questionId": "12",
-        "questionText": "Count evidence of substance use. Look for bottles, cans, or paraphernalia that once held alccohol, prescriptions, or illicit drugs.",
+        "questionText": "Count evidence of substance use. Look for bottles, cans, or paraphernalia that once held alcohol, prescriptions, or illicit drugs.",
         "ratingOption1": "None",
         "ratingOption2": "1 or more",
         "ratingOption3": "",


### PR DESCRIPTION
# Overview
Updated question.json to correct spelling of Alcohol.

To test, work through a walkthrough and see that alcohol is no longer misspelled. 

This question can be found in:
School grounds question 7.
Pick-up Area question 5.

# Screenshot
![image](https://user-images.githubusercontent.com/23063720/39158325-420208a0-4714-11e8-93ad-4670624cfa4a.png)

![image](https://user-images.githubusercontent.com/23063720/39158428-df1833a8-4714-11e8-8fc6-68276a16908c.png)

# Trello Link
https://trello.com/c/uBbmOW3w/80-bug-fix-spelling

# Merge Checklist
[X] Backmerged master in your branch.